### PR TITLE
Disable pwm macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@
 # Currently supported BUMPS, CRAMPS, and VGEN5
 export BEAGLEG_HARDWARE_TARGET?=BUMPS
 
+# Disable PWM timers. See README.md.
+#export CONFIG_FLAGS?=-D_DISABLE_PWM_TIMERS
+
 # In case you cross compile this on a different architecture, uncomment this
 # and set the prefix of the compiler binary.
 #export CROSS_COMPILE?=arm-arago-linux-gnueabi-

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ socket (you can just telnet to it for an interactive session, how cool is that?)
 
 ## Install
 ### System configuration
+
 In order to run BeagleG on your BeagleBone you will need to be sure
 that uio_pruss kernel module has been installed and loaded in the kernel.
 You can easily test if the module it's available by running:
@@ -52,6 +53,28 @@ yet. You can see that if you ask `uname -r` returns something like
 
 In that case, you will need to
 [change your kernel version](http://elinux.org/BeagleBoardDebian#Install_Latest_Kernel_Image) to a bone prefix one (e.g. `4.4.14-bone`).
+
+#### Newer kernels
+Newest beagleboard kernels support both remoteproc and uio_pruss modules.
+In order to use the uio_pruss one simply follow the directives that you can find inside `/boot/uEnv.txt`:
+
+```
+###PRUSS OPTIONS
+###pru_rproc (4.4.x-ti kernel)
+#uboot_overlay_pru=/lib/firmware/AM335X-PRU-RPROC-4-4-TI-00A0.dtbo
+###pru_uio (4.4.x-ti & mainline/bone kernel)
+uboot_overlay_pru=/lib/firmware/AM335X-PRU-UIO-00A0.dtbo
+```
+
+Some 4.4 linux kernel versions do not have the timers drivers not enabled.
+In order to be able to use the PWM you would need to recompile the kernel with
+CONFIG_OMAP_DM_TIMER=y.
+
+In order to use BeagleG **without** the PWM TIMERS support, you can compile beagleg with:
+```
+CONFIG_FLAGS=-D_DISABLE_PWM_TIMERS make
+```
+
 
 ### Build
 To build, we need the BeagleG code and the PRU assembler with supporting library.

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,6 +9,10 @@
 # Currently supported BUMPS, CRAMPS, and VGEN5
 BEAGLEG_HARDWARE_TARGET?=BUMPS
 
+# Additional macros, for example to disable the pwm support simply add
+# -D_DISABLE_PWM_TIMERS
+CONFIG_FLAGS?=
+
 # In case you cross compile this on a different architecture, uncomment this
 # and set the prefix. Or simply set the environment variable.
 #CROSS_COMPILE?=arm-arago-linux-gnueabi-
@@ -46,7 +50,7 @@ CFLAGS+=-Wall -I. -I$(INCDIR_APP_LOADER) -I$(CAPE_INCLUDE) -D_XOPEN_SOURCE=500 $
 # We use c++11, but it looks like that even the latest
 # bone-debian-7.11-lxde-4gb-armhf-2016-06-16-4gb image has an ancient 4.6.3
 # compiler that still referred to that standard as c++0x
-CXXFLAGS+=-std=c++0x $(CFLAGS)
+CXXFLAGS+=-std=c++0x $(CFLAGS) $(CONFIG_FLAGS)
 CXX?=g++
 
 LDFLAGS+=-lpthread -lm

--- a/src/hardware-mapping.cc
+++ b/src/hardware-mapping.cc
@@ -120,10 +120,15 @@ bool HardwareMapping::InitializeHardware() {
     Log_error("Couldn't mmap() GPIO ranges.\n");
     return false;
   }
+
+#ifdef _DISABLE_PWM_TIMERS
+  Log_info("PWM timers are disabled.\n");
+#else
   if (!pwm_timers_map()) {
     Log_error("Couldn't mmap() TIMER ranges.\n");
     return false;
   }
+
 
   // The PWM_*_GPIO pins can produce PWM signals if they are mapped to one
   // of the TIMER pins and the dts set the pins to the correct mode (0x02).
@@ -141,6 +146,7 @@ bool HardwareMapping::InitializeHardware() {
   pwm_timer_set_freq(PWM_2_GPIO, 0);
   pwm_timer_set_freq(PWM_3_GPIO, 0);
   pwm_timer_set_freq(PWM_4_GPIO, 0);
+#endif
 
   is_hardware_initialized_ = true;
   ResetHardware();
@@ -207,6 +213,9 @@ void HardwareMapping::SetAuxOutputs() {
 }
 
 void HardwareMapping::SetPWMOutput(LogicOutput type, float value) {
+#ifdef _DISABLE_PWM_TIMERS
+  return;
+#else
   if (!is_hardware_initialized_) return;
   const uint32_t gpio = output_to_pwm_gpio_[type];
   if (value <= 0.0) {
@@ -215,6 +224,7 @@ void HardwareMapping::SetPWMOutput(LogicOutput type, float value) {
     pwm_timer_set_duty(gpio, value);
     pwm_timer_start(gpio, true);
   }
+#endif
 }
 
 std::string HardwareMapping::DebugMotorString(LogicAxis axis) {


### PR DESCRIPTION
Added macro definition to disable PWM, if someone is stuck with a kernel not supporting the pwm, but still wants to use beagleg.