### PR TITLE
Add a clang-tidy configuration and script to run.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,57 @@
+---
+# Disabled some clang-analyzer static checks, need some more investigation.
+# TODO(hzeller) fix and re-enable clang-analyzer checks.
+# TODO(hzeller) Looking over magic numbers might be good, but probably
+#               not worthwhile hard-failing
+# TODO(hzeller) Explore anofalloff suggestions.
+#
+# readability-make-member-function-const is great, but it also suggests that
+#    in cases where we return a non-const pointer. So good to check, not by
+#    default.
+#
+# readability-qualified-auto is useful in general, however it suggests
+#    to convert iterators (e.g. std::string_view::begin()) to the pointer it
+#    returns; however since the iterator is implementation defined, this is not
+#    a valid assertion. Running the check every now and then manually and
+#    fixing all the non-iterator cases is useful though. Off by default.
+##
+Checks: >
+  clang-diagnostic-*,clang-analyzer-*,
+  -clang-analyzer-core.NonNullParamChecker,
+  -clang-analyzer-cplusplus.NewDeleteLeaks,
+  -clang-diagnostic-unused-const-variable,
+  readability-*,
+  -readability-braces-around-statements,
+  -readability-else-after-return,
+  -readability-function-cognitive-complexity,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-magic-numbers,
+  -readability-make-member-function-const,
+  -readability-named-parameter,
+  -readability-qualified-auto,
+  -readability-redundant-access-specifiers,
+  -readability-use-anyofallof,
+  google-*,
+  -google-readability-avoid-underscore-in-googletest-name
+  -google-readability-braces-around-statements,
+  -google-readability-todo,
+  performance-*,
+  bugprone-*,
+  -bugprone-branch-clone,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-exception-escape,
+  -bugprone-move-forwarding-reference,
+  -bugprone-narrowing-conversions,
+  -bugprone-reserved-identifier,
+  modernize-use-override,
+  misc-*,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-redundant-expression,
+  -misc-unused-parameters,
+
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+...

--- a/.github/bin/make-compilation-db.sh
+++ b/.github/bin/make-compilation-db.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -u
+
+TMPDIR="${TMPDIR:-/tmp}"
+readonly BUILD_OUT=${TMPDIR}/build.out
+
+make clean > /dev/null 2>&1
+BEAR_COMMAND_SEPARATOR="--"
+if bear --version | grep "2\.4" ; then
+    # Older versions of bear did not have the -- separator. The github actions
+    # run on an Ubuntu which still has the 2.4 version.
+    BEAR_COMMAND_SEPARATOR=""
+fi
+time bear ${BEAR_COMMAND_SEPARATOR} make -C src all test-binaries > ${BUILD_OUT} 2>&1
+
+if [ $? -ne 0 ]; then
+    cat ${BUILD_OUT}
+    echo "Build failure."
+    exit 1
+fi
+echo "done."
+exit 0

--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -u
+
+TMPDIR="${TMPDIR:-/tmp}"
+
+readonly PARALLEL_COUNT=$(nproc)
+readonly FILES_PER_INVOCATION=5
+
+readonly FILES_TO_PROCESS=${TMPDIR}/clang-tidy-files.list
+readonly TIDY_OUT=${TMPDIR}/clang-tidy.out
+
+# Using clang-tidy-11 as it is the last one still checking for
+# google-runtime-references, non-const references in parameters - which is
+# the preferred style in this project.
+readonly CLANG_TIDY=clang-tidy-11
+hash ${CLANG_TIDY} || exit 2  # make sure it is installed.
+
+echo ::group::Build compilation database
+
+$(dirname $0)/make-compilation-db.sh
+if [ $? -ne 0 ]; then
+    echo "::error::Can't generate compilation database."
+    exit 1
+fi
+
+find src -name "*.h" -o -name "*.cc" > ${FILES_TO_PROCESS}
+
+echo "::endgroup::"
+
+echo "::group::Run ${CLANG_TIDY} on $(wc -l < ${FILES_TO_PROCESS}) files"
+
+cat ${FILES_TO_PROCESS} \
+    | xargs -P${PARALLEL_COUNT} -n ${FILES_PER_INVOCATION} -- \
+            ${CLANG_TIDY} --quiet 2>/dev/null \
+            > ${TIDY_OUT}.tmp
+
+# Only modify at the end, so we can inspect the file manually while a new run
+# of this script is in progress.
+mv ${TIDY_OUT}.tmp ${TIDY_OUT}
+
+cat ${TIDY_OUT}
+
+echo "::endgroup::"
+
+if [ -s ${TIDY_OUT} ]; then
+
+    # Tidy results were non-empty. Put a summary into a separate group.
+    echo "::group::Summary"
+    # Give a nice overview of how many counts of which problem found.
+    sed 's|\(.*\)\(\[[a-zA-Z.-]*\]$\)|\2|p;d' < ${TIDY_OUT} | sort | uniq -c | sort -n
+    echo "::endgroup::"
+
+    echo "::error::There were clang-tidy warnings. Please fix"
+    echo "::warning::This will be a CI failure soon. For now just FYI and waived until baseline is fixed."
+    exit 0
+    #exit 1  # not yet.
+fi
+
+echo "No clang-tidy complaints.😎"
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,26 @@ jobs:
 
     - name: Run formatting style check
       run: ./.github/bin/run-clang-format.sh
+
+  ClangTidy:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get install googletest bear clang-tidy-11
+
+    - name: Configure shell
+      # Since we're not compiling on the Beaglebone, disable arm specifics
+      run: |
+        echo 'ARM_COMPILE_FLAGS=' >> $GITHUB_ENV
+
+    - name: Run clang tidy
+      run: ./.github/bin/run-clang-tidy.sh

--- a/src/Makefile
+++ b/src/Makefile
@@ -105,10 +105,13 @@ test-html: test-out/test.html
 test-out/test.html: gcode2ps test-create-html.sh testdata/*.gcode
 	./test-create-html.sh testdata/*.gcode
 
-local-tests: $(UNITTEST_BINARIES)
+test-binaries: $(UNITTEST_BINARIES)
+	for d in $(SUBDIRS) ; do $(MAKE) -C $$d test-binaries || exit 1; done
+
+local-tests: test-binaries
 	for test_bin in $(UNITTEST_BINARIES) ; do echo ; echo $$test_bin; ./$$test_bin || exit 1 ; done
 
-local-valgrind-tests: $(UNITTEST_BINARIES)
+local-valgrind-tests: test-binaries
 	for test_bin in $(UNITTEST_BINARIES) ; do valgrind --track-origins=yes --leak-check=full --error-exitcode=1 -q ./$$test_bin || exit 1; done
 
 test: local-tests

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -40,10 +40,12 @@ all : $(GENLIB)
 $(GENLIB): $(OBJECTS)
 	$(AR) rcs $@ $^
 
-test: $(UNITTEST_BINARIES)
+test-binaries: $(UNITTEST_BINARIES)
+
+test: test-binaries
 	for test_bin in $(UNITTEST_BINARIES) ; do echo ; echo $$test_bin; ./$$test_bin || exit 1 ; done
 
-valgrind-test: $(UNITTEST_BINARIES)
+valgrind-test: test-binaries
 	for test_bin in $(UNITTEST_BINARIES) ; do valgrind --track-origins=yes --leak-check=full --error-exitcode=1 -q ./$$test_bin || exit 1; done
 
 

--- a/src/gcode-parser/Makefile
+++ b/src/gcode-parser/Makefile
@@ -43,10 +43,12 @@ $(GENLIB): $(OBJECTS)
 ../common/libbeaglegbase.a:
 	$(MAKE) -C ../common
 
-test: $(UNITTEST_BINARIES)
+test-binaries: $(UNITTEST_BINARIES)
+
+test: test-binaries
 	for test_bin in $(UNITTEST_BINARIES) ; do echo ; echo $$test_bin; ./$$test_bin || exit 1 ; done
 
-valgrind-test: $(UNITTEST_BINARIES)
+valgrind-test: test-binaries
 	for test_bin in $(UNITTEST_BINARIES) ; do valgrind --track-origins=yes --leak-check=full --error-exitcode=1 -q ./$$test_bin || exit 1; done
 
 


### PR DESCRIPTION
It is also run in the CI, but for now does not exit fail yet
as we have to first fix our legacy issues.