### PR TITLE
config-pin location has changed; provide path to script.

### DIFF
--- a/hardware/BUMPS/bumps.pins
+++ b/hardware/BUMPS/bumps.pins
@@ -1,4 +1,5 @@
-# Run with config-pin -f BUMPS.pins
+# Run with /opt/source/bb.org-overlays/tools/beaglebone-universal-io/config-pin -f bumps.pins
+#
 # Step signals.
 P9.18 low     # motor 1 (top left Pololu;    BUMPS v0.1 label "Z")
 P9.17 low     # motor 2 (bottom left Pololu; BUMPS v0.1 label "E")

--- a/hardware/Pockegotion/README.md
+++ b/hardware/Pockegotion/README.md
@@ -10,7 +10,7 @@ will have a couple of opto-coupled inputs and PWM outputs.
 Pins are defined with the universal overlay, so can be loaded with
 
 ```
-config-pin -f pockegotion.pins
+/opt/source/bb.org-overlays/tools/beaglebone-universal-io/config-pin -f pockegotion.pins
 ```
 
 The 'cape' is pretty much experimental right now:

--- a/hardware/VGEN5/README.md
+++ b/hardware/VGEN5/README.md
@@ -17,13 +17,21 @@ To support the VGEN5 cape, BeagleG must be built using the correct hardware targ
 make BEAGLEG_HARDWARE_TARGET=VGEN5
 ```
 
+## The config-pin utility
+
+There are two `config-pin` utilities in current installations.
+
+  * The shell script `/opt/source/bb.org-overlays/tools/beaglebone-universal-io/config-pin` is the tool we're using here.
+  * `/usr/bin/config-pin` seems to be the latest one which has slightly different options (and the script needs to be adapted).
+
 ## Overlay and I/O configuration
 
-The config-pin utility can be used to load the overlay.
+The config-pin utility can be used to load the overlay (might not be needed
+anymore in recent installations, as it should be loaded by default)
 
 ```
 # Load the cape-universal overlay
-config-pin overlay cape-universal
+/opt/source/bb.org-overlays/tools/beaglebone-universal-io/config-pin overlay cape-universal
 ```
 
 At this point, the various devices are loaded and all the gpio have been
@@ -38,7 +46,7 @@ The pin configuration can also be setup from a file such as
 
 ```
 # Configure the I/O pins
-config-pin -f vgen5.pins
+/opt/source/bb.org-overlays/tools/beaglebone-universal-io/config-pin -f vgen5.pins
 ```
 
 ## Machine control


### PR DESCRIPTION
The old 'config-pin' script is not compatible with the `config-pin`
binary found in newer installations. Until the *.pin files are adapted,
make sure to have the documentation point to the right place.