### PR TITLE
Test and fix for moving non-euclidean axes in arcs

### DIFF
--- a/src/gcode-parser/arc-gen.cc
+++ b/src/gcode-parser/arc-gen.cc
@@ -40,6 +40,8 @@
 // of arcs with the BeagleBone Black CPU. Sufficient :)
 #define MM_PER_ARC_SEGMENT 0.1
 
+typedef EnumIterable<GCodeParserAxis, AXIS_A, GCODE_NUM_AXES> AllAxesFromA;
+
 // Generate an arc. Input is the
 static bool arc_gen(
   enum GCodeParserAxis normal_axis,  // Normal axis
@@ -48,6 +50,7 @@ static bool arc_gen(
   const AxesRegister &center,        // Offset to center.
   const AxesRegister &target,        // Target position.
   const std::function<bool(const AxesRegister &)> &segment_output) {
+
   // Depending on the normal vector, pre-calc plane
   enum GCodeParserAxis plane[3];
   switch (normal_axis) {
@@ -113,9 +116,13 @@ static bool arc_gen(
 
   // Figure out how many segments for this gcode
   const int segments = floorf(mm_of_travel / MM_PER_ARC_SEGMENT);
-
   const float theta_per_segment = angular_travel / segments;
   const float linear_per_segment = linear_travel / segments;
+
+  AxesRegister other_axes_per_segment;
+  for (const GCodeParserAxis a : AllAxesFromA()) {
+    other_axes_per_segment[a] = (target[a] - position[a]) / segments;
+  }
 
   for (int i = 1; i < segments; i++) {  // Increment (segments-1)
     const float cos_Ti = cosf(i * theta_per_segment);
@@ -128,14 +135,18 @@ static bool arc_gen(
     position[plane[1]] = center_1 + r_1;
     position[plane[2]] += linear_per_segment;
 
+    // Update other axis position
+    for (const GCodeParserAxis a : AllAxesFromA()) {
+      position[a] += other_axes_per_segment[a];
+    }
+
     // Emit
     if (!segment_output(position)) return false;
   }
 
   // Ensure last segment arrives at target location.
-  for (int axis = AXIS_X; axis <= AXIS_Z; axis++) {
-    position[(GCodeParserAxis)axis] = target[(GCodeParserAxis)axis];
-  }
+  position = target;
+
   return segment_output(position);
 }
 

--- a/src/gcode-parser/arc-gen.cc
+++ b/src/gcode-parser/arc-gen.cc
@@ -50,7 +50,6 @@ static bool arc_gen(
   const AxesRegister &center,        // Offset to center.
   const AxesRegister &target,        // Target position.
   const std::function<bool(const AxesRegister &)> &segment_output) {
-
   // Depending on the normal vector, pre-calc plane
   enum GCodeParserAxis plane[3];
   switch (normal_axis) {

--- a/src/gcode-parser/arc-gen_test.cc
+++ b/src/gcode-parser/arc-gen_test.cc
@@ -59,7 +59,8 @@ class TestArcAccumulator : public GCodeParser::EventReceiver {
   }
 
   float total_len() const { return total_len_; }
-  AxesRegister last() const { return last_; }
+
+  const AxesRegister &last() const { return last_; }
 
   bool rapid_move(float feed_mm_p_sec, const AxesRegister &absolute_pos) final {
     return true;
@@ -155,10 +156,10 @@ static void testArcLength(GCodeParserAxis normal, bool clockwise, double start,
   }
 }
 
-TEST(ArcGenerator, ArcLength_NonEuclideanAxes) {
+TEST(ArcGenerator, ArcLength_InterpolateNonEuclideanAxes) {
   AxesRegister start, center, target;
   const double kTurnAngle = M_PI;
-  const float kAxisALenght = 20.0;
+  const float kAxisALength = 20.0;
 
   start[AXIS_X] = 1.0;
   start[AXIS_Y] = 0.0;
@@ -169,13 +170,12 @@ TEST(ArcGenerator, ArcLength_NonEuclideanAxes) {
 
   target[AXIS_X] = cos(kTurnAngle);
   target[AXIS_Y] = sin(kTurnAngle);
-  target[AXIS_A] = kAxisALenght;
+  target[AXIS_A] = kAxisALength;
 
   TestArcAccumulator collect(start);
   collect.arc_move(100, AXIS_Z, true, start, center, target);
-  EXPECT_NEAR(collect.last()[AXIS_A], kAxisALenght, 0.003);
+  EXPECT_NEAR(collect.last()[AXIS_A], kAxisALength, 0.003);
 }
-
 
 TEST(ArcGenerator, ArcLength_CW_360) {
   testArcLength(AXIS_X, true, TEST_ARC_STEP, TEST_ARC_STEP, 2 * M_PI);


### PR DESCRIPTION
We are using beagleg (thanks for this super nice project, btw!) to drive stepper motors systems for industrial machines. In most cases, the system is made by XYZ axis, plus one or more axes to drive single or multiple extruders (A, B, E etc). Those tools needs to be synced with the motion during the process, that's why interpolating A, B... axes with X, Y, Z is actually needed.
 
It works perfectly for points and lines, but not with arcs, where non-euclidean axes are ignored.

This pull request tries to solve this issue by adding a test (with an arc on the XY plane and a linear motion for A) and a small fix in `arc_gen.cc` to make it pass.