### PR TITLE
Added command M181.

### DIFF
--- a/src/gcode-machine-control.cc
+++ b/src/gcode-machine-control.cc
@@ -75,6 +75,9 @@ class GCodeMachineControl::Impl final : public GCodeParser::EventReceiver {
   HomingState GetHomeStatus();
   bool GetMotorsEnabled();
   void GetCurrentPosition(AxesRegister *pos);
+  bool SetLookahead(int size) { return planner_->SetLookahead(size); }
+  int Lookahead() const { return planner_->Lookahead(); }
+  int GetMaxLookahead() const { return planner_->GetMaxLookahead(); }
 
   // -- GCodeParser::Events interface implementation --
   void gcode_start(GCodeParser *parser) final;
@@ -122,7 +125,7 @@ class GCodeMachineControl::Impl final : public GCodeParser::EventReceiver {
                     int max_steps);
   void home_axis(enum GCodeParserAxis axis);
   void set_output_flags(HardwareMapping::NamedOutput out, bool is_on);
-  void set_lookahead(int size);
+  const char *handle_set_lookahead(const char *);
   void handle_M105();
   // Parse GCode spindle M3/M4 block.
   const char *set_spindle_on(bool is_ccw, const char *);
@@ -451,20 +454,33 @@ bool GCodeMachineControl::Impl::check_for_pause() {
   return hardware_mapping_->TestPauseSwitch();
 }
 
-void GCodeMachineControl::Impl::set_lookahead(int size) {
-  // It is necessary to have a fully stopped machine to change lookahead.
-  // This is to avoid introducing a delay between the requested change and
-  // actual machine behavior with previously enqueued segments.
+const char *GCodeMachineControl::Impl::handle_set_lookahead(
+  const char *remaining) {
+  char letter;
+  float value;
+  const char *const after_pair =
+    parser_->ParsePair(remaining, &letter, &value, msg_stream_);
+  const int max_lookahead = GetMaxLookahead();
+
+  // No argument, set lookahead to max.
+  if (after_pair == NULL) {
+    motor_ops_->WaitQueueEmpty();
+    const bool is_set = SetLookahead(max_lookahead);
+    assert(is_set);
+    return remaining;
+  }
+
+  // Unrecognized pair.
+  if (letter != 'S') return after_pair;
+  const int lookahead = (int)value;
+  if (lookahead <= 0 || lookahead > max_lookahead) {
+    mprintf("// ERROR: allowed range 1 <= S <= %d\n", max_lookahead);
+    return after_pair;
+  }
   motor_ops_->WaitQueueEmpty();
-  const bool set_max = size < 0;
-  size = (size <= 0) ? -1 : size;
-  const bool set = planner_->SetLookAhead(&size);
-  if (set_max) {
-    planner_->SetLookAhead(&size);
-  }
-  if (!set) {
-    mprintf("// ERROR: allowed range 1 <= S <= %d\n", size);
-  }
+  const bool is_set = SetLookahead(lookahead);
+  assert(is_set);
+  return after_pair;
 }
 
 void GCodeMachineControl::Impl::handle_M105() {
@@ -551,14 +567,9 @@ const char *GCodeMachineControl::Impl::special_commands(char letter,
   case 119: mprint_endstop_status(); break;
   case 120: pause_enabled_ = true; break;
   case 121: pause_enabled_ = false; break;
-  case 181: {
-    const char *const after_pair = parser_->ParsePair(remaining, &letter, &value, msg_stream_);
-    if (remaining == NULL) set_lookahead(-1);
-    else if (letter == 'S') set_lookahead((unsigned)value);
-    else break;
-    remaining = after_pair;
+  case 181:
+    remaining = handle_set_lookahead(remaining);
     break;
-  }
   default:
     mprintf("// BeagleG: didn't understand ('%c', %d, '%s')\n",
             letter, code, remaining);
@@ -1103,4 +1114,14 @@ GCodeParser::EventReceiver *GCodeMachineControl::ParseEventReceiver() {
 
 void GCodeMachineControl::SetMsgOut(FILE *msg_stream) {
   impl_->set_msg_stream(msg_stream);
+}
+
+bool GCodeMachineControl::SetLookahead(int size) {
+  return impl_->SetLookahead(size);
+}
+
+int GCodeMachineControl::Lookahead() const { return impl_->Lookahead(); }
+
+int GCodeMachineControl::GetMaxLookahead() const {
+  return impl_->GetMaxLookahead();
 }

--- a/src/gcode-machine-control.h
+++ b/src/gcode-machine-control.h
@@ -123,6 +123,18 @@ class GCodeMachineControl {
   // Can only be called in the same thread that also handles gcode updates.
   void GetCurrentPosition(AxesRegister *pos);
 
+  // Set the internal planner queue size.
+  // Used to trade-off between command sent - executed motion latency
+  // and maximum achievable speed.
+  // Requires 0 < size <= GetMaxLookahead(), returns true on success.
+  bool SetLookahead(int size);
+
+  // Retrieve the internal planning queue size.
+  int Lookahead() const;
+
+  // Get the maximum allowed lookahead size.
+  int GetMaxLookahead() const;
+
  private:
   class Impl;
 

--- a/src/gcode-parser/gcode-parser_test.cc
+++ b/src/gcode-parser/gcode-parser_test.cc
@@ -1035,6 +1035,13 @@ TEST(GCodeParserTest, WhileLoop) {
   EXPECT_EQ(1024, counter.get_parameter(2));
 }
 
+TEST(GCodeParserTest, Unprocessed) {
+  ParseTester counter;
+
+  EXPECT_TRUE(counter.TestParseLine("M181 S300"));
+  EXPECT_EQ(1, counter.call_count[CALL_unprocessed]);
+}
+
 int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/planner.cc
+++ b/src/planner.cc
@@ -472,9 +472,11 @@ bool Planner::Impl::issue_motor_move_if_possible(
   fprintf(stderr, "]\n");
 #endif
 
-  // We require a slot to be always present.
-  if (num_segments == 0 && (planning_buffer_.size() == lookahead_size_))
-    ++num_segments;
+  // Count the amount of segments that are extra the lookahead size.
+  const int segments_extra = planning_buffer_.size() - lookahead_size_;
+  if (num_segments == 0 && (segments_extra >= 0))
+    num_segments =
+      segments_extra + 1;  // Always pop one free slot for the next.
 
   // No segments to enqueue, skip.
   if (!num_segments) return ret;

--- a/src/planner.h
+++ b/src/planner.h
@@ -64,6 +64,16 @@ class Planner {
   // Precondition: BringPathToHalt() had been called before.
   void SetExternalPosition(GCodeParserAxis axis, float pos);
 
+  // Set/get internal planning buffer size. Trade-off between
+  // command sent - executed motion latency and maximum achievable speed.
+  // Set the internal planning queue to the value pointed by size.
+  // If size is nullptr, this is a no-op and false is returned.
+  // Special size 0 returns false and sets size to the current value.
+  // Negative size values, or size values above the internal maximum
+  // will not change the internal state and set size to the maximum value
+  // instead.
+  bool SetLookAhead(int *size);
+
  private:
   class Impl;
   Impl *const impl_;

--- a/src/planner.h
+++ b/src/planner.h
@@ -64,15 +64,17 @@ class Planner {
   // Precondition: BringPathToHalt() had been called before.
   void SetExternalPosition(GCodeParserAxis axis, float pos);
 
-  // Set/get internal planning buffer size. Trade-off between
-  // command sent - executed motion latency and maximum achievable speed.
-  // Set the internal planning queue to the value pointed by size.
-  // If size is nullptr, this is a no-op and false is returned.
-  // Special size 0 returns false and sets size to the current value.
-  // Negative size values, or size values above the internal maximum
-  // will not change the internal state and set size to the maximum value
-  // instead.
-  bool SetLookAhead(int *size);
+  // Set the internal planner queue size.
+  // Used to trade-off between command sent - executed motion latency
+  // and maximum achievable speed.
+  // Requires 0 < size <= GetMaxLookahead(), returns true on success.
+  bool SetLookahead(int size);
+
+  // Retrieve the internal planning queue size.
+  int Lookahead() const;
+
+  // Get the maximum allowed lookahead size.
+  int GetMaxLookahead() const;
 
  private:
   class Impl;


### PR DESCRIPTION
- Parser shall route to unprocessed commands.
- GCodeMachineControl shall handle the command and set the value to max if no S<value> pair is provided. Added single test that only checks the motor ops queue shall be emptied before changing the planner size.
- Planner respect the lookahead value and always push older commands to maintain planning queue size. No tests added.