### PR TITLE
Add flake.nix wrapping shell.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ gcode2ps
 test-out/
 compile_commands.json
 .cache
+flake.lock

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,14 @@
+{
+  description = "BeagleG dev shell";
+
+  # nixos-unstable @ 2026-06-26
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = import nixpkgs { inherit system; };
+      in {
+        devShells.default = import ./shell.nix { inherit pkgs; };
+      });
+}


### PR DESCRIPTION
## Summary
- Adds a `flake.nix` whose `devShells.default` imports the existing `shell.nix`, so `nix develop` works alongside `nix-shell` with a single source of truth for dependencies.
- No `flake.lock` is committed: inputs float on `nixos-unstable`, matching the existing `shell.nix` behaviour (which already tracks `<nixpkgs>`). Nix will auto-create a local lock on first run.

## Test plan
- [x] `nix-shell --run "clang-format --version"` still works.
- [x] `nix develop --command bash -c "clang-format --version"` enters the same environment.