### PR TITLE
Package beagleg with nix: flake, cross-compile, PRU toolchain

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -49,6 +49,36 @@ the root of the environment.
 nix-shell
 ```
 
+The shell pulls in the host build deps: gtest, valgrind, clang-tools,
+lcov, ghostscript, graphviz.
+
+#### Building with the flake
+
+There is also a `flake.nix` that exposes BeagleG as a nix package and
+supports cross-compilation to the BeagleBone target out of the box. The
+`am335x_pru_package` git submodule is followed transparently via
+`inputs.self.submodules = true;` in the flake.
+
+Each program is its own flake output (and so is its cross-compiled
+counterpart suffixed `-armv7`):
+
+```
+# run any program directly
+nix run .#machine-control -- --help
+nix run .#gcode2ps testdata/some.gcode
+
+# build a single binary (result/bin/<name>)
+nix build .#gcode-print-stats
+
+# cross-compile a single binary for the BeagleBone (armv7l-hf)
+nix build .#machine-control-armv7
+
+# list every flake output (packages, dev shells, ...)
+nix flake show
+```
+
+The cross-built binaries are ARM EABI5 ELFs ready to scp onto a BBB.
+
 ### Coverage
 To see if there is code that has not been covered in tests yet, there is
 a target `make coverage`, that creates a `src/coverage.html` report with

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ cool is that?).
 For detailed system configuration and building the `machine-control` binary, see
 [INSTALL.md](./INSTALL.md).
 
+If you use the [nix](https://nixos.org/) package manager, BeagleG ships with
+a `flake.nix` that builds the project hermetically and can cross-compile to
+the BeagleBone target straight from an x86 dev box — no toolchain to install
+by hand, identical builds across machines. See [Development.md](./Development.md#nixos)
+for the one-liner.
+
 Before you can use beagleg and get meaningful outputs on the GPIO pins,
 two things are required on a fresh Beaglebone installation (we recommend the
 IoT image).

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,47 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
+  # Follow the am335x_pru_package git submodule transparently, so users
+  # don't need to add ?submodules=1 to every nix-build invocation.
+  inputs.self.submodules = true;
+
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = import nixpkgs { inherit system; };
+    # BeagleG is linux-only; expose the flake on every linux system
+    # nixpkgs considers reasonable (incl. armv7l-linux for native builds
+    # on a BeagleBone itself, aarch64-linux for RPi-class boards, etc.).
+    flake-utils.lib.eachSystem
+      (nixpkgs.lib.filter (s: nixpkgs.lib.hasSuffix "-linux" s)
+        nixpkgs.lib.systems.flakeExposed)
+      (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        lib = pkgs.lib;
+        beagleg = pkgs.callPackage ./nix/beagleg.nix { };
+
+        # Cross-compile targets. Add one line per new architecture; the
+        # suffix becomes the flake-output suffix (e.g. machine-control-armv7).
+        crossTargets = {
+          armv7 = pkgs.pkgsCross.armv7l-hf-multiplatform;
+        };
+
+        # Binaries shipped by the package. Each becomes its own flake
+        # output with mainProgram set, so `nix run .#gcode2ps` picks the
+        # right entrypoint. All outputs share the same underlying build.
+        binaries = [ "machine-control" "gcode-print-stats" "gcode2ps" ];
+        mkRunnable = drv: name: drv.overrideAttrs (_: {
+          meta = drv.meta // { mainProgram = name; };
+        });
+        named = drv: suffix: lib.listToAttrs (map (name: {
+          name = name + suffix;
+          value = mkRunnable drv name;
+        }) binaries);
+        crossPackages = lib.concatMapAttrs
+          (suffix: cross: named (cross.callPackage ./nix/beagleg.nix { }) "-${suffix}")
+          crossTargets;
       in {
         devShells.default = import ./shell.nix { inherit pkgs; };
+        packages = { default = beagleg; }
+          // (named beagleg "")
+          // crossPackages;
       });
 }

--- a/nix/beagleg.nix
+++ b/nix/beagleg.nix
@@ -1,0 +1,59 @@
+# BeagleG host package. Builds machine-control and its companion tools
+# from the project Makefile. Supports native builds (for tests / dev) and
+# cross-compilation to armv7 for BeagleBone deployment via pkgsCross.
+{ stdenv, lib, pkg-config, gtest, pkgsBuildBuild }:
+stdenv.mkDerivation {
+  pname = "beagleg";
+  version = "unstable";
+
+  # Pass the project root directly (not lib.cleanSource) so the
+  # am335x_pru_package submodule is included in the build sandbox.
+  src = ./..;
+
+  # pasm's linuxbuild needs a build-platform C compiler to produce the
+  # PRU assembler binary that then runs in this sandbox.
+  nativeBuildInputs = [ pkg-config pkgsBuildBuild.gcc ];
+  CC_FOR_BUILD = "${pkgsBuildBuild.gcc}/bin/gcc";
+  buildInputs = [ gtest ];
+
+  # Patches for the vendored am335x_pru_package:
+  #  - K&R-style ppCleanup() / definition pair rejected by strict GCC.
+  #  - linuxbuild calls bare `gcc`, which under nix cross-builds is only
+  #    available with the build-platform prefix; use $CC_FOR_BUILD.
+  postPatch = ''
+    substituteInPlace am335x_pru_package/pru_sw/utils/pasm_source/pasm.h \
+      --replace-fail 'void ppCleanup();' 'void ppCleanup(int);'
+    substituteInPlace am335x_pru_package/pru_sw/utils/pasm_source/pasmpp.c \
+      --replace-fail 'void ppCleanup()' 'void ppCleanup(int Pass)'
+    substituteInPlace am335x_pru_package/pru_sw/utils/pasm_source/linuxbuild \
+      --replace-fail 'gcc -Wall' "''${CC_FOR_BUILD:-gcc} -Wall"
+  '';
+
+  # The Makefile's ARM_COMPILE_FLAGS default targets cortex-a8/armv7-a,
+  # which is what we want for BBB cross builds. Clear it on any host that
+  # isn't a 32-bit ARM (nix's stdenv has already set the right CC/CXX).
+  ARM_COMPILE_FLAGS = lib.optionalString (!stdenv.hostPlatform.isAarch32) "";
+
+  enableParallelBuilding = true;
+
+  # Tests are gtest-based and run on the build machine; skip when cross-
+  # compiling because the binaries can't execute on the build host.
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  checkTarget = "test";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -m 755 machine-control gcode-print-stats $out/bin/
+    install -m 755 src/gcode2ps $out/bin/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Step-motor controller for CNC-like devices using the BeagleBone PRU";
+    homepage = "https://github.com/hzeller/beagleg";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    mainProgram = "machine-control";
+  };
+}


### PR DESCRIPTION
flake.nix exposes:
  packages.machine-control        - native build
  packages.machine-control-armv7  - cross-compiled for BeagleBone (armv7)

The vendored am335x_pru_package submodule is followed transparently via `inputs.self.submodules = true;`, so the usual nix build .#X works without a ?submodules=1 query.

nix/beagleg.nix wraps the project Makefile in a stdenv derivation. It patches the vendored pasm (a K&R-style ppCleanup() prototype recent strict-prototype GCC rejects, and a linuxbuild script that calls bare `gcc` which is only prefixed under nix-cross), clears ARM_COMPILE_FLAGS on non-ARM hosts, and skips tests when cross-compiling.

nix/pru-toolchain.nix builds GNU binutils 2.43 from upstream with --target=pru-elf; nixpkgs has no pkgsCross.pru entry (lib.systems.parse does not know "pru" as a CPU family). The PRU is freestanding so no gcc-pru is needed: the remoteproc resource_table can be written in pure PRU assembly and assembled by pru-elf-as alongside the PASM-produced firmware bytes.

shell.nix exposes binutils-pru in the dev shell; Development.md and the README pick up the new flake outputs.