### PR TITLE
Fix SetExternalPosition storing magnitude instead of signed steps

### DIFF
--- a/src/motion-queue-motor-operations.cc
+++ b/src/motion-queue-motor-operations.cc
@@ -238,11 +238,10 @@ void MotionQueueMotorOperations::SetExternalPosition(int axis, int steps) {
   struct HistorySegment history_segment = shadow_queue_->front();
   if (steps < 0) {
     history_segment.pos_info[axis].sign = -1;
-    history_segment.pos_info[axis].position_steps = -steps;
   } else {
     history_segment.pos_info[axis].sign = 1;
-    history_segment.pos_info[axis].position_steps = steps;
   }
+  history_segment.pos_info[axis].position_steps = steps;
   shadow_queue_->push_front(history_segment);
   // Shrink the queue and remove the elements that we are not interested
   // in anymore.

--- a/src/motion-queue-motor-operations_test.cc
+++ b/src/motion-queue-motor-operations_test.cc
@@ -61,6 +61,24 @@ TEST(RealtimePosition, init_pos) {
   EXPECT_THAT(expected, ::testing::ContainerEq(status.pos_steps));
 }
 
+TEST(RealtimePosition, set_external_position_negative) {
+  HardwareMapping hw;
+  MockMotionQueue motion_backend = MockMotionQueue();
+  MotionQueueMotorOperations motor_operations(&hw, &motion_backend);
+
+  motor_operations.SetExternalPosition(0, -12345);
+
+  PhysicalStatus status;
+  motor_operations.GetPhysicalStatus(&status);
+  EXPECT_EQ(-12345, status.pos_steps[0]);
+
+  const LinearSegmentSteps segment = {0, 0, 0, {100, 0, 0, 0, 0, 0, 0, 0}};
+  motor_operations.Enqueue(segment);
+  motion_backend.SimRun(0, 1);
+  motor_operations.GetPhysicalStatus(&status);
+  EXPECT_EQ(-12245, status.pos_steps[0]);
+}
+
 // Check that the steps are correctly evaluated from the shadow queue
 // with the correct sign.
 TEST(RealtimePosition, back_and_forth) {


### PR DESCRIPTION
## Bug

`MotionQueueMotorOperations::SetExternalPosition()` in
`src/motion-queue-motor-operations.cc` stores the wrong value when
`steps` is negative:

```cpp
if (steps < 0) {
  history_segment.pos_info[axis].sign = -1;
  history_segment.pos_info[axis].position_steps = -steps;  // stores |steps|
} else {
  history_segment.pos_info[axis].sign = 1;
  history_segment.pos_info[axis].position_steps = steps;
}
```

`position_steps` ends up holding the magnitude, not the signed
absolute machine position, whenever a negative external position is
set. Every other place `position_steps` is used in this file treats it
as a genuine signed coordinate:

- `EnqueueInternal()`'s running accumulator: `position_steps += param.steps[i]`
- `GetPhysicalStatus()`'s interpolation: `position_steps - sign*(int)steps`

so the stored value silently loses its sign right after
`SetExternalPosition()` and all subsequent `GetPhysicalStatus()` reads
for that axis are corrupted until the next `SetExternalPosition()`
call.

This is reachable from a normal G-code path: `gcode-machine-control.cc`'s
`probe_axis()` (used by G30) computes
`new_pos = machine_pos[axis] + distance_moved` (which can be negative,
e.g. probing below the current axis zero) and calls
`planner_->SetExternalPosition(axis, new_pos)`, which converts to an
integer motor step count and forwards it to this function unchanged.

## Fix

Store `steps` unconditionally; only use the sign check to set the
`sign` field used for the interpolation math, matching the convention
used everywhere else in the file:

```cpp
if (steps < 0) {
  history_segment.pos_info[axis].sign = -1;
} else {
  history_segment.pos_info[axis].sign = 1;
}
history_segment.pos_info[axis].position_steps = steps;
```

## Testing

Built a host-side harness against the unmodified sources and confirmed
the bug: calling `SetExternalPosition(0, -12345)` followed by
`GetPhysicalStatus()` reported `pos_steps[0] == 12345` (sign lost)
instead of `-12345`, and a subsequent +5-step move reported `12350`
instead of the expected `-12340`.

With the fix applied, both cases report the correct signed values
(`-12345` and `-12340`).

Also rebuilt and ran the existing
`src/motion-queue-motor-operations_test.cc` suite unmodified before
and after the change — all 5 existing tests
(`init_pos`, `back_and_forth`, `empty_element`, `sample_pos`,
`zero_loops_edge`) still pass, so this is a non-behavior-changing fix
for all previously-covered (non-negative) cases.