### PR TITLE
string_views: Make code compatible with c++11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,19 @@ jobs:
         compiler:
           - g++
           - clang++
+        cpp_standard:
+          - "-std=c++17"
+          - "-std=c++20"
         optimization: [ 0, 1, 2, 3]
 
-    name: Test ${{matrix.compiler}} -O${{matrix.optimization}}
+    name: Test ${{matrix.compiler}} ${{ matrix.cpp_standard }} -O${{matrix.optimization}}
     steps:
     - name: Prepare
       run: |
         sudo apt-get update -qq
         sudo apt install -y g++ clang pkg-config libgtest-dev libgmock-dev valgrind
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
         fetch-depth: 0
@@ -34,6 +37,7 @@ jobs:
       run: |
         echo "ARM_COMPILE_FLAGS=" >> $GITHUB_ENV
         echo "CXX=${{ matrix.compiler }}" >> $GITHUB_ENV
+        echo "CPP_STANDARD=${{ matrix.cpp_standard }}" >> $GITHUB_ENV
         echo "BEAGLEG_OPT_CFLAGS=-O${{ matrix.optimization }} -Werror" >> $GITHUB_ENV
 
     - name: Build
@@ -47,6 +51,46 @@ jobs:
     - name: Valgrind Test
       run: |
         make valgrind-test
+
+  build-and-test_cpp11:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    name: Test c++11-compat
+    steps:
+    - name: Prepare
+      run: |
+        sudo apt-get update -qq
+        sudo apt install -y clang pkg-config
+
+    - uses: actions/checkout@v7
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Install GoogleTest 1.12.1
+      run: |
+        git clone --branch release-1.12.1 --depth 1 https://github.com/google/googletest.git
+        cd googletest
+        cmake -B build -DCMAKE_BUILD_TYPE=Release
+        sudo cmake --build build --target install
+
+    - name: Configure shell
+      # Since we're not compiling on the Beaglebone, disable arm specifics
+      run: |
+        echo "ARM_COMPILE_FLAGS=" >> $GITHUB_ENV
+        echo "CXX=clang++" >> $GITHUB_ENV   # g++ does not support c++11 anymore
+        echo "CPP_STANDARD=-std=c++11" >> $GITHUB_ENV
+        echo "BEAGLEG_OPT_CFLAGS=-O2 -Werror" >> $GITHUB_ENV
+
+    - name: Build
+      run: |
+        make
+
+    - name: Test
+      run: |
+        make test
 
   hardware-targets:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@
 PREFIX?=/usr/local
 BINDIR=$(PREFIX)/bin
 
+export CPP_STANDARD?=-std=c++17   # we're compatible down to 11
+
 all machine-control:
 	$(MAKE) -e -C src all
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,18 @@
 { pkgs ? import <nixpkgs> {} }:
+let
+  # Want a gtest version that is compatible with c++11
+  gtest_1_12_1 = pkgs.gtest.overrideAttrs (oldAttrs: rec {
+    version = "1.12.1";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "google";
+      repo = "googletest";
+      rev = "release-${version}";
+      hash = "sha256-W+OxRTVtemt2esw4P7IyGWXOonUN5ZuscjvzqkYvZbM=";
+    };
+    patches = [];
+  });
+in
 pkgs.mkShell {
   buildInputs = with pkgs;
     [
@@ -7,7 +21,7 @@ pkgs.mkShell {
       git
       lcov
       bear
-      gtest
+      gtest_1_12_1
       valgrind
       ghostscript
       llvmPackages_19.clang-tools

--- a/src/Makefile
+++ b/src/Makefile
@@ -46,7 +46,7 @@ GIT_VERSION=$(shell git log -n1 --date=short --format="%cd (commit=%h)" 2>/dev/n
 CFLAGS+=-Wall -Wextra -W -Wno-unused-parameter -I$(shell pwd) -I$(INCDIR_APP_LOADER) -I$(CAPE_INCLUDE) -D_XOPEN_SOURCE=500 $(ARM_COMPILE_FLAGS) $(BEAGLEG_OPT_CFLAGS) -DCAPE_NAME='"$(BEAGLEG_HARDWARE_TARGET)"' -DBEAGLEG_VERSION='"$(GIT_VERSION)"'
 
 # Expected to have at least c++17 on all systems these days.
-CXXFLAGS+=-std=c++17 $(CFLAGS) $(CONFIG_FLAGS)
+CXXFLAGS+=$(CPP_STANDARD) $(CFLAGS) $(CONFIG_FLAGS)
 CXX?=g++
 
 LDFLAGS+=-lpthread -lm

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -12,7 +12,7 @@ BEAGLEG_OPT_CFLAGS?=-O3
 
 CFLAGS+=-Wall -Wextra -W -Wno-unused-result -Wno-unused-parameter -D_XOPEN_SOURCE=500 $(ARM_COMPILE_FLAGS) $(BEAGLEG_OPT_CFLAGS) -I$(shell pwd)/..
 
-CXXFLAGS+=-std=c++17 $(CFLAGS)
+CXXFLAGS+=$(CPP_STANDARD) $(CFLAGS)
 CXX?=g++
 
 LDFLAGS+=-lpthread -lm

--- a/src/common/container_test.cc
+++ b/src/common/container_test.cc
@@ -24,7 +24,9 @@
 TEST(FixedArray, BasicOp) {
   FixedArray<int, 3> buffer;
   EXPECT_EQ(buffer.size(), 3u);
+#if __cplusplus >= 201703L
   static_assert(buffer.size() == 3);  // compile-time constexpr
+#endif
 
   buffer[0] = 1;
   buffer[1] = 2;
@@ -61,9 +63,10 @@ TEST(RingDeque, BasicOp) {
 
 TEST(RingDeque, Wrapping) {
   RingDeque<int, 4> buffer;
-  EXPECT_EQ(buffer.capacity(), 3u);       // one less than CAPACITY
+  EXPECT_EQ(buffer.capacity(), 3u);  // one less than CAPACITY
+#if __cplusplus >= 201703L
   static_assert(buffer.capacity() == 3);  // compile-time constexpr
-
+#endif
   // Advance the internal positions so that we force wrapping.
   *buffer.append() = 42;
   *buffer.append() = 42;

--- a/src/common/string-util.cc
+++ b/src/common/string-util.cc
@@ -25,7 +25,6 @@
 
 #include <algorithm>
 #include <cctype>
-#include <charconv>
 #include <cstdint>
 #include <cstdlib>
 #include <string>
@@ -35,34 +34,38 @@
 #include <utility>
 #include <vector>
 
-std::string_view TrimWhitespace(std::string_view s) {
-  std::string_view::iterator start = s.begin();
+#if __cplusplus >= 201703L
+#include <charconv>
+#endif
+
+beagleg::string_view TrimWhitespace(beagleg::string_view s) {
+  beagleg::string_view::iterator start = s.begin();
   while (start < s.end() && isspace(*start)) start++;
-  std::string_view::iterator end = s.end() - 1;
+  beagleg::string_view::iterator end = s.end() - 1;
   while (end > start && isspace(*end)) end--;
-  return std::string_view(start, end + 1 - start);
+  return beagleg::string_view(start, end + 1 - start);
 }
 
-std::string ToLower(std::string_view in) {
+std::string ToLower(beagleg::string_view in) {
   std::string result(in.length(), ' ');
   std::transform(in.begin(), in.end(), result.begin(), ::tolower);
   return result;
 }
 
-bool HasPrefix(std::string_view s, std::string_view prefix) {
+bool HasPrefix(beagleg::string_view s, beagleg::string_view prefix) {
   if (s.length() < prefix.length()) return false;
   return strncmp(s.data(), prefix.data(), prefix.length()) == 0;  // NOLINT
 }
 
-static inline bool contains(std::string_view str, char c) {
-  return str.find_first_of(c) != std::string_view::npos;
+static inline bool contains(beagleg::string_view str, char c) {
+  return str.find_first_of(c) != beagleg::string_view::npos;
 }
 
-std::vector<std::string_view> SplitString(std::string_view s,
-                                          std::string_view separators) {
-  std::vector<std::string_view> result;
-  std::string_view::iterator i = s.begin();
-  std::string_view::iterator start = i;
+std::vector<beagleg::string_view> SplitString(beagleg::string_view s,
+                                              beagleg::string_view separators) {
+  std::vector<beagleg::string_view> result;
+  beagleg::string_view::iterator i = s.begin();
+  beagleg::string_view::iterator start = i;
   for (/**/; i != s.end(); ++i) {
     if (contains(separators, *i)) {
       result.emplace_back(start, i - start);
@@ -72,41 +75,6 @@ std::vector<std::string_view> SplitString(std::string_view s,
   result.emplace_back(start, i - start);
   return result;
 }
-
-template <typename value_type>
-static const char *convert_strto_num(std::string_view s, value_type *result) {
-  while (!s.empty() && isspace(s.front())) s.remove_prefix(1);
-  if (!s.empty() && s.front() == '+') s.remove_prefix(1);
-  auto success = std::from_chars(s.data(), s.data() + s.size(), *result);
-  return (success.ec == std::errc()) ? success.ptr : nullptr;
-}
-const char *convert_strto32(std::string_view s, int32_t *result) {
-  return convert_strto_num<int32_t>(s, result);
-}
-const char *convert_strto64(std::string_view s, int64_t *result) {
-  return convert_strto_num<int64_t>(s, result);
-}
-
-/*
- * So, unfortunately not all c++17 implemenetations actually provide
- * a std::from_chars() for floating point numbers; available only >= g++-11
- * for instance.
- *
- * So here we use the c++ detection pattern to determine if that function
- * is available, otherwise fall back to slower best-effort implementation that
- * copies it to a nul-terminated buffer, then calls the old strtof(), strotd()
- * functions.
- */
-template <typename T, typename = void>
-struct from_chars_available : std::false_type {};
-template <typename T>
-struct from_chars_available<
-  T, std::void_t<decltype(std::from_chars(
-       std::declval<const char *>(), std::declval<const char *>(),
-       std::declval<T &>()))>> : std::true_type {};
-
-template <typename T>
-inline constexpr bool from_chars_available_v = from_chars_available<T>::value;
 
 // Copy everything that looks like a number into output iterator.
 static void CopyNumberTo(const char *in_begin, const char *in_end,
@@ -132,19 +100,70 @@ static void CopyNumberTo(const char *in_begin, const char *in_end,
   *dst = '\0';
 }
 
+template <typename value_type>
+static const char *convert_strto_num(beagleg::string_view s,
+                                     value_type *result) {
+  while (!s.empty() && isspace(s.front())) s.remove_prefix(1);
+  if (!s.empty() && s.front() == '+') s.remove_prefix(1);
+#if __cplusplus >= 201703L
+  auto success = std::from_chars(s.data(), s.data() + s.size(), *result);
+  return (success.ec == std::errc()) ? success.ptr : nullptr;
+#else
+  char buffer[32];
+  beagleg::string_view n = s;
+  while (!n.empty() && isspace(n.front())) n.remove_prefix(1);
+  CopyNumberTo(n.data(), n.data() + n.size(), buffer, buffer + sizeof(buffer));
+
+  char *endptr = nullptr;
+  *result = strtoll(buffer, &endptr, 10);
+  if (endptr == buffer) return nullptr;
+  return n.data() + (endptr - buffer);
+#endif
+}
+const char *convert_strto32(beagleg::string_view s, int32_t *result) {
+  return convert_strto_num<int32_t>(s, result);
+}
+const char *convert_strto64(beagleg::string_view s, int64_t *result) {
+  return convert_strto_num<int64_t>(s, result);
+}
+
+#if __cplusplus >= 201703L
+/*
+ * So, unfortunately not all c++17 implemenetations actually provide
+ * a std::from_chars() for floating point numbers; available only >= g++-11
+ * for instance.
+ *
+ * So here we use the c++ detection pattern to determine if that function
+ * is available, otherwise fall back to slower best-effort implementation that
+ * copies it to a nul-terminated buffer, then calls the old strtof(), strotd()
+ * functions.
+ */
+template <typename T, typename = void>
+struct from_chars_available : std::false_type {};
+template <typename T>
+struct from_chars_available<
+  T, std::void_t<decltype(std::from_chars(
+       std::declval<const char *>(), std::declval<const char *>(),
+       std::declval<T &>()))>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool from_chars_available_v = from_chars_available<T>::value;
+#endif
+
 template <typename T, T (*strto_fallback_fun)(const char *, char **)>
-static const char *convert_strto_ieee(std::string_view s, T *result) {
+static const char *convert_strto_ieee(beagleg::string_view s, T *result) {
+#if __cplusplus >= 201703L
   if constexpr (from_chars_available_v<T>) {
     return convert_strto_num<T>(s, result);
   }
-
+#endif
   // Fallback in case std::from_chars() does not exist for this type. Here,
   // we just call the corresponding C-function, but first have to copy
   // the number to a local buffer, as that one requires \0-termination.
   char buffer[32];
 
   // Need to skip whitespace first to not use up our buffer for that.
-  std::string_view n = s;
+  beagleg::string_view n = s;
   while (!n.empty() && isspace(n.front())) n.remove_prefix(1);
 
   CopyNumberTo(n.data(), n.data() + n.size(), buffer, buffer + sizeof(buffer));
@@ -156,16 +175,16 @@ static const char *convert_strto_ieee(std::string_view s, T *result) {
   return n.data() + (endptr - buffer);
 }
 
-const char *convert_strtof(std::string_view s, float *result) {
+const char *convert_strtof(beagleg::string_view s, float *result) {
   return convert_strto_ieee<float, strtof>(s, result);
 }
 
-const char *convert_strtod(std::string_view s, double *result) {
+const char *convert_strtod(beagleg::string_view s, double *result) {
   return convert_strto_ieee<double, strtod>(s, result);
 }
 
 // Parse decimal and return on success or return fallback value otherwise.
-int64_t ParseInt64(std::string_view s, int64_t fallback) {
+int64_t ParseInt64(beagleg::string_view s, int64_t fallback) {
   int64_t result;
   return convert_strto64(s, &result) ? result : fallback;
 }

--- a/src/common/string-util.h
+++ b/src/common/string-util.h
@@ -23,48 +23,159 @@
 #include <stddef.h>
 
 #include <cstdint>
-#include <ostream>
 #include <string>
-#include <string_view>
 #include <vector>
+
+#if __cplusplus >= 201703L
+#include <string_view>
+#else
+#include <cstring>
+#include <ostream>
+#endif
 
 // Define this with empty, if you're not using gcc.
 #define PRINTF_FMT_CHECK(fmt_pos, args_pos) \
   __attribute__((format(printf, fmt_pos, args_pos)))
 
-// Trim std::string_view of whitespace font and back and returned trimmed
+namespace beagleg {
+#if __cplusplus >= 201703L
+using string_view = ::std::string_view;
+#else
+// Our version of c++17 std::string_view in case c++17 is not available yet.
+// It essentially points at a chunk of data of a particular
+// length. Pointer + length.
+// Allows to have keep cheap substrings of strings without copy while still
+// have a type-safe, length-aware piece of string.
+class string_view {
+ public:
+  typedef const char *iterator;
+  static const size_t npos = -1;
+
+  string_view() : data_(NULL), len_(0) {}
+  string_view(const char *data, size_t len) : data_(data), len_(len) {}
+
+  // We want implicit conversions from these types
+  string_view(const std::string &s)  // NOLINT
+      : data_(s.data()), len_(s.length()) {}
+  string_view(const char *str)  // NOLINT
+      : data_(str), len_(strlen(str)) {}
+
+  string_view substr(size_t pos, size_t len) const {
+    assert(pos + len <= len_);
+    return string_view(data_ + pos, len);
+  }
+  string_view substr(size_t pos) const { return substr(pos, length() - pos); }
+
+  bool operator==(const string_view &other) const {
+    if (len_ != other.len_) return false;
+    if (data_ == other.data_) return true;
+    return strncmp(data_, other.data_, len_) == 0;
+  }
+
+  char operator[](size_t pos) const { return data_[pos]; }
+  const char &front() const { return data_[0]; }
+  const char *data() const { return data_; }
+  size_t length() const { return len_; }
+  size_t size() const { return len_; }
+  bool empty() const { return len_ == 0; }
+
+  iterator begin() const { return data_; }
+  iterator end() const { return data_ + len_; }
+
+  size_t find_first_of(char c) const {
+    const char *found = strchr(data_, c);
+    return found ? found - data_ : npos;
+  }
+
+  // Not optimized. Just make work.
+  size_t find(string_view s, size_t pos = 0) const {
+    const size_t self_len = this->size();
+    const size_t s_len = s.size();
+
+    if (pos > self_len) return npos;
+    if (s_len == 0) return pos;
+    if (s_len > self_len - pos) return npos;
+
+    using traits_type = std::char_traits<char>;
+
+    // single char..
+    const char *data = this->data();
+    if (s_len == 1) {
+      const char *ptr = traits_type::find(data + pos, self_len - pos, s[0]);
+      return ptr ? static_cast<size_t>(ptr - data) : npos;
+    }
+
+    // multi-char
+    const char first_char = s[0];
+    const size_t max_search_pos = self_len - s_len;
+
+    for (size_t i = pos; i <= max_search_pos; ++i) {
+      // Find candidate match for the first character
+      const char *candidate =
+        traits_type::find(data + i, max_search_pos - i + 1, first_char);
+      if (!candidate) return npos;  // not even first char found.
+
+      i = static_cast<size_t>(candidate - data);
+
+      // Check if the remainder of the substring matches
+      if (traits_type::compare(candidate + 1, s.data() + 1, s_len - 1) == 0) {
+        return i;
+      }
+    }
+
+    return npos;
+  }
+
+  void remove_prefix(size_t n) {
+    n = n < len_ ? n : len_;
+    data_ += n;
+    len_ -= n;
+  }
+
+ private:
+  const char *data_;
+  size_t len_;
+};
+
+inline std::ostream &operator<<(std::ostream &o, string_view s) {
+  return o.write(s.data(), s.length());
+}
+#endif
+}  // namespace beagleg
+
+// Trim beagleg::string_view of whitespace font and back and returned trimmed
 // string.
-std::string_view TrimWhitespace(std::string_view s);
+beagleg::string_view TrimWhitespace(beagleg::string_view s);
 
 // Lowercase the string (simple ASCII) and return as newly allocated
 // std::string
-std::string ToLower(std::string_view in);
+std::string ToLower(beagleg::string_view in);
 
-// Test if given std::string_view is prefix of the other.
-bool HasPrefix(std::string_view s, std::string_view prefix);
+// Test if given beagleg::string_view is prefix of the other.
+bool HasPrefix(beagleg::string_view s, beagleg::string_view prefix);
 
 // Formatted printing into a string.
 std::string StringPrintf(const char *format, ...) PRINTF_FMT_CHECK(1, 2);
 
 // Split a string at any of the given separator characters.
-std::vector<std::string_view> SplitString(std::string_view s,
-                                          std::string_view separators);
+std::vector<beagleg::string_view> SplitString(beagleg::string_view s,
+                                              beagleg::string_view separators);
 
-// Parse a number from a std::string_view into "result". Returns the
+// Parse a number from a beagleg::string_view into "result". Returns the
 // end of the number on success, nullptr otherwise.
 // So this can be used in a simple boolean context for simple success
 // testing, but as well in parsing context where advancing to the next position
 // is needed.
-const char *convert_strto32(std::string_view s, int32_t *result);
-const char *convert_strto64(std::string_view s, int64_t *result);
-const char *convert_strtof(std::string_view s, float *result);
-const char *convert_strtod(std::string_view s, double *result);
+const char *convert_strto32(beagleg::string_view s, int32_t *result);
+const char *convert_strto64(beagleg::string_view s, int64_t *result);
+const char *convert_strtof(beagleg::string_view s, float *result);
+const char *convert_strtod(beagleg::string_view s, double *result);
 
 // Possible convenience functions
-// bool consume_strtof(std::string_view *s, float *result);
+// bool consume_strtof(beagleg::string_view *s, float *result);
 
 // Parse integer. On success, return parsed number, fallback otherwise.
-int64_t ParseInt64(std::string_view s, int64_t fallback);
+int64_t ParseInt64(beagleg::string_view s, int64_t fallback);
 
 #undef PRINTF_FMT_CHECK
 #endif  // _BEAGLEG_STRING_UTIL_H

--- a/src/common/string-util_test.cc
+++ b/src/common/string-util_test.cc
@@ -24,8 +24,9 @@
 #include <cstdint>
 #include <vector>
 
+namespace beagleg {
 TEST(StringUtilTest, TrimWhitespace) {
-  EXPECT_EQ("hello", TrimWhitespace(" \t  hello \n\r  "));
+  EXPECT_EQ(string_view{"hello"}, TrimWhitespace(" \t  hello \n\r  "));
   EXPECT_TRUE(TrimWhitespace(" \t ").empty());
 }
 
@@ -40,23 +41,23 @@ TEST(StringUtilTest, HasPrefix) {
 }
 
 TEST(StringUtilTest, SplitString) {
-  std::vector<std::string_view> result = SplitString("foo", ",");
+  std::vector<beagleg::string_view> result = SplitString("foo", ",");
   EXPECT_EQ(1, (int)result.size());
-  EXPECT_EQ("foo", result[0]);
+  EXPECT_EQ(string_view{"foo"}, result[0]);
 
   result = SplitString(",hello, world", ",");
   EXPECT_EQ(3, (int)result.size());
-  EXPECT_EQ("", result[0]);
-  EXPECT_EQ("hello", result[1]);
-  EXPECT_EQ(" world", result[2]);
+  EXPECT_EQ(string_view{""}, result[0]);
+  EXPECT_EQ(string_view{"hello"}, result[1]);
+  EXPECT_EQ(string_view{" world"}, result[2]);
 
   // Also test with trailing, empty field
   result = SplitString(",hello, world,", ",");
   EXPECT_EQ(4, (int)result.size());
-  EXPECT_EQ("", result[0]);
-  EXPECT_EQ("hello", result[1]);
-  EXPECT_EQ(" world", result[2]);
-  EXPECT_EQ("", result[3]);
+  EXPECT_EQ(string_view{""}, result[0]);
+  EXPECT_EQ(string_view{"hello"}, result[1]);
+  EXPECT_EQ(string_view{" world"}, result[2]);
+  EXPECT_EQ(string_view{""}, result[3]);
 }
 
 TEST(StringUtilTest, ParseDecimalInt) {
@@ -75,12 +76,12 @@ TEST(StringUtilTest, ParseDecimalInt) {
   EXPECT_EQ(12345678901234LL, ParseInt64("12345678901234", -1));
 
   // Make sure we're not assumming a nul-byte at a particular point
-  const std::string_view longer_string("4255");
+  const beagleg::string_view longer_string("4255");
   EXPECT_EQ(42, ParseInt64(longer_string.substr(0, 2), -1));
 
   // Make sure the returned value points to the characters after the number.
-  const std::string_view input = " +314cm";
-  const std::string_view expected_remain = input.substr(input.find("cm"));
+  const beagleg::string_view input = " +314cm";
+  const beagleg::string_view expected_remain = input.substr(input.find("cm"));
   const char *remain_string = convert_strto64(input, &value);
   ASSERT_TRUE(remain_string);
   EXPECT_EQ(314, value);
@@ -100,8 +101,8 @@ TEST(StringUtilTest, ParseFloat) {
   EXPECT_EQ(123, value);
 
   // Make sure the returned value points to the characters after the number.
-  const std::string_view input = " +314.159cm";
-  const std::string_view expected_remain = input.substr(input.find("cm"));
+  const beagleg::string_view input = " +314.159cm";
+  const beagleg::string_view expected_remain = input.substr(input.find("cm"));
   const char *remain_string = convert_strtof(input, &value);
   ASSERT_TRUE(remain_string);
   EXPECT_NEAR(314.159, value, 0.0001);
@@ -121,13 +122,14 @@ TEST(StringUtilTest, ParseDouble) {
   EXPECT_EQ(123, value);
 
   // Make sure the returned value points to the characters after the number.
-  const std::string_view input = " +314.159cm";
-  const std::string_view expected_remain = input.substr(input.find("cm"));
+  const beagleg::string_view input = " +314.159cm";
+  const beagleg::string_view expected_remain = input.substr(input.find("cm"));
   const char *remain_string = convert_strtod(input, &value);
   ASSERT_TRUE(remain_string);
   EXPECT_NEAR(314.159, value, 0.00001);
   EXPECT_EQ(remain_string, expected_remain.data());  // pointers must match.
 }
+}  // namespace beagleg
 
 int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/config-parser.cc
+++ b/src/config-parser.cc
@@ -71,18 +71,19 @@ static double ParseDoubleExpression(const char *input, double fallback,
   return value;
 }
 
-bool ConfigParser::Reader::ParseString(std::string_view value,
+bool ConfigParser::Reader::ParseString(beagleg::string_view value,
                                        std::string *result) {
   // Possibly in the future if needed: c-escapes.
   result->assign(value.data(), value.length());
   return true;
 }
 
-bool ConfigParser::Reader::ParseInt(std::string_view value, int32_t *result) {
+bool ConfigParser::Reader::ParseInt(beagleg::string_view value,
+                                    int32_t *result) {
   return convert_strto32(value, result);
 }
 
-bool ConfigParser::Reader::ParseBool(std::string_view value, bool *result) {
+bool ConfigParser::Reader::ParseBool(beagleg::string_view value, bool *result) {
   if (value == "1" || value == "yes" || value == "true") {
     *result = true;
     return true;
@@ -121,37 +122,37 @@ bool ConfigParser::SetContentFromFile(const char *filename) {
   return file_stream.good();
 }
 
-void ConfigParser::SetContent(std::string_view content) {
+void ConfigParser::SetContent(beagleg::string_view content) {
   content_.assign(content.begin(), content.end());
 }
 
 // Extract next line out of source; returns line, modifies "source"
 // to point to next
 // Modifies source.
-static std::string_view NextLine(std::string_view *source) {
-  std::string_view result;
+static beagleg::string_view NextLine(beagleg::string_view *source) {
+  beagleg::string_view result;
   if (source->empty()) return result;
-  const std::string_view::iterator start = source->begin();
-  std::string_view::iterator endline = start;
+  const beagleg::string_view::iterator start = source->begin();
+  beagleg::string_view::iterator endline = start;
   for (/**/; endline != source->end(); ++endline) {
     // Whatever newline or comment comes first terminates our resulting line...
     if (!result.data() &&
         (*endline == '#' || *endline == '\r' || *endline == '\n')) {
-      result = std::string_view(start, endline - start);
+      result = beagleg::string_view(start, endline - start);
     }
     if (*endline == '\n') {  // ... but we wait until \n to reposition source
-      *source =
-        std::string_view(endline + 1, source->length() - (endline - start) - 1);
+      *source = beagleg::string_view(endline + 1,
+                                     source->length() - (endline - start) - 1);
       return result;
     }
   }
   // Encountered last line without final newline.
-  result = std::string_view(start, endline - start);
-  *source = std::string_view(source->end(), 0);
+  result = beagleg::string_view(start, endline - start);
+  *source = beagleg::string_view(source->end(), 0);
   return result;
 }
 
-static std::string CanonicalizeName(const std::string_view s) {
+static std::string CanonicalizeName(const beagleg::string_view s) {
   return ToLower(TrimWhitespace(s));
 }
 
@@ -160,8 +161,8 @@ bool ConfigParser::EmitConfigValues(Reader *reader) const {
   bool current_section_interested = false;
   std::string current_section;
   int line_no = 0;
-  std::string_view content_data(content_.data(), content_.length());
-  std::string_view line = NextLine(&content_data);
+  beagleg::string_view content_data(content_.data(), content_.length());
+  beagleg::string_view line = NextLine(&content_data);
   for (/**/; line.data() != NULL; line = NextLine(&content_data)) {
     ++line_no;
     line = TrimWhitespace(line);
@@ -176,12 +177,12 @@ bool ConfigParser::EmitConfigValues(Reader *reader) const {
         continue;
       }
 
-      const std::string_view section = line.substr(1, line.length() - 2);
+      const beagleg::string_view section = line.substr(1, line.length() - 2);
       current_section = CanonicalizeName(section);
       current_section_interested =
         reader->SeenSection(line_no, current_section);
     } else {
-      std::string_view::iterator eq_pos =
+      beagleg::string_view::iterator eq_pos =
         std::find(line.begin(), line.end(), '=');
       if (eq_pos == line.end()) {
         reader->ReportError(line_no, "name=value pair expected.");
@@ -190,9 +191,9 @@ bool ConfigParser::EmitConfigValues(Reader *reader) const {
       }
       if (current_section_interested) {
         const std::string name = CanonicalizeName(
-          std::string_view(line.begin(), eq_pos - line.begin()));
-        const std::string_view value_piece =
-          TrimWhitespace(std::string_view(eq_pos + 1, line.end() - eq_pos - 1));
+          beagleg::string_view(line.begin(), eq_pos - line.begin()));
+        const beagleg::string_view value_piece = TrimWhitespace(
+          beagleg::string_view(eq_pos + 1, line.end() - eq_pos - 1));
         const std::string value(value_piece.begin(), value_piece.end());
         const bool could_parse = reader->SeenNameValue(line_no, name, value);
         if (!could_parse) {

--- a/src/config-parser.h
+++ b/src/config-parser.h
@@ -21,8 +21,8 @@
 
 #include <cstdint>
 #include <string>
-#include <string_view>
-#include <vector>
+
+#include "common/string-util.h"
 
 // The config parser reads a configuration file and passes tokenized
 // values to a ConfigParser::Reader.
@@ -63,9 +63,9 @@ class ConfigParser {
     // All the Accept() functions are done in the way that they always return
     // 'true' if the expected name is not matched, otherwise they return the
     // outcome of parsing the value. That way, they can be chained with &&
-    static bool ParseString(std::string_view value, std::string *result);
-    static bool ParseInt(std::string_view value, int32_t *result);
-    static bool ParseBool(std::string_view value, bool *result);
+    static bool ParseString(beagleg::string_view value, std::string *result);
+    static bool ParseInt(beagleg::string_view value, int32_t *result);
+    static bool ParseBool(beagleg::string_view value, bool *result);
     static bool ParseFloatExpr(const std::string &value, float *result);
   };
 
@@ -82,7 +82,7 @@ class ConfigParser {
   // Set content of configuration file as one string. Typically useful in
   // unit tests.
   // Overwrites any previous content.
-  void SetContent(std::string_view content);
+  void SetContent(beagleg::string_view content);
 
   // Emit configuration values to the Reader for all sections it is interested
   // in.

--- a/src/gcode-parser/Makefile
+++ b/src/gcode-parser/Makefile
@@ -12,7 +12,7 @@ BEAGLEG_OPT_CFLAGS?=-O3
 
 CFLAGS+=-Wall -Wextra -W -Wno-unused-parameter -D_XOPEN_SOURCE=500 $(ARM_COMPILE_FLAGS) $(BEAGLEG_OPT_CFLAGS) -I$(shell pwd)/..
 
-CXXFLAGS+=-std=c++17 $(CFLAGS)
+CXXFLAGS+=$(CPP_STANDARD) $(CFLAGS)
 CXX?=g++
 
 LDFLAGS+=-lpthread -lm

--- a/src/gcode-parser/arc-gen.cc
+++ b/src/gcode-parser/arc-gen.cc
@@ -162,10 +162,13 @@ static AxesRegister calc_bezier_point(float t, const AxesRegister &p0,
   AxesRegister p = p0;
   p[AXIS_X] = uuu * p0[AXIS_X];  // first term
   p[AXIS_Y] = uuu * p0[AXIS_Y];
+
   p[AXIS_X] += (3.0f * uu * t * p1[AXIS_X]);  // second term
   p[AXIS_Y] += (3.0f * uu * t * p1[AXIS_Y]);
+
   p[AXIS_X] += (3.0f * u * tt * p2[AXIS_X]);  // third term
   p[AXIS_Y] += (3.0f * u * tt * p2[AXIS_Y]);
+
   p[AXIS_X] += (ttt * p3[AXIS_X]);  // forth term
   p[AXIS_Y] += (ttt * p3[AXIS_Y]);
   return p;

--- a/src/gcode-parser/gcode-parser.cc
+++ b/src/gcode-parser/gcode-parser.cc
@@ -264,7 +264,7 @@ class GCodeParser::Impl {
   const char *read_param_name(const char *line, std::string *result);
 
   // Read parameter. Do range check.
-  bool read_parameter(std::string_view param_name, float *result) const {
+  bool read_parameter(beagleg::string_view param_name, float *result) const {
     *result = 0;
     if (config_.parameters == NULL) return false;
     param_name = TrimWhitespace(param_name);
@@ -280,7 +280,7 @@ class GCodeParser::Impl {
   }
 
   // Read parameter. Do range check.
-  bool store_parameter(std::string_view param_name, float value) {
+  bool store_parameter(beagleg::string_view param_name, float value) {
     if (config_.parameters == NULL) return false;
     param_name = TrimWhitespace(param_name);
     // zero parameter can never be written.
@@ -1059,7 +1059,7 @@ void GCodeParser::Impl::gcodep_while_end() {
 
     line = skip_white(endptr);
     if (control_parse_.ExpectNext(&line, CK_DO)) {
-      for (const std::string_view wline : SplitString(while_loop_, "\n")) {
+      for (const beagleg::string_view wline : SplitString(while_loop_, "\n")) {
         // TODO(hzeller):ParseBlock needs to accept string_view
         const std::string tmp(wline.begin(), wline.end());
         ParseBlock(while_owner_, tmp.c_str(), while_err_stream_);

--- a/src/gcode2ps.cc
+++ b/src/gcode2ps.cc
@@ -56,7 +56,6 @@
 #include <unistd.h>  // IWYU pragma: keep (getopt_long)
 
 #include <algorithm>
-#include <complex>
 #include <cstring>
 #include <functional>
 #include <map>

--- a/src/hardware-mapping.cc
+++ b/src/hardware-mapping.cc
@@ -460,7 +460,7 @@ class HardwareMapping::ConfigReader : public ConfigParser::Reader {
   }
 
   bool SetMotorAxis(int line_no, int motor_number, const std::string &in_val) {
-    std::vector<std::string_view> options = SplitString(in_val, " \t,");
+    std::vector<beagleg::string_view> options = SplitString(in_val, " \t,");
     for (size_t i = 0; i < options.size(); ++i) {
       const std::string option = ToLower(options[i]);
       if (HasPrefix(option, "axis:")) {
@@ -493,7 +493,7 @@ class HardwareMapping::ConfigReader : public ConfigParser::Reader {
 
   bool SetSwitchOptions(int line_no, int switch_number,
                         const std::string &value) {
-    std::vector<std::string_view> options = SplitString(value, " \t,");
+    std::vector<beagleg::string_view> options = SplitString(value, " \t,");
     for (size_t i = 0; i < options.size(); ++i) {
       const std::string option = ToLower(options[i]);
       if (option.empty()) continue;
@@ -585,7 +585,8 @@ const char *HardwareMapping::OutputToName(NamedOutput output) {
   return "<invalid>";
 }
 
-bool HardwareMapping::NameToOutput(std::string_view str, NamedOutput *result) {
+bool HardwareMapping::NameToOutput(beagleg::string_view str,
+                                   NamedOutput *result) {
   const std::string n = ToLower(str);
   // clang-format off
 #define MAP_VAL(condition, val) if (condition)  do { *result = val; return true; } while(0)

--- a/src/hardware-mapping.h
+++ b/src/hardware-mapping.h
@@ -23,9 +23,9 @@
 #include <stdint.h>
 
 #include <string>
-#include <string_view>
 
 #include "common/container.h"
+#include "common/string-util.h"
 #include "gcode-parser/gcode-parser.h"  // For GCodeParserAxis
 #include "segment-queue.h"
 
@@ -263,7 +263,7 @@ class HardwareMapping {
 
   // Converts the human readable name of an output to the enumeration if
   // possible.
-  static bool NameToOutput(std::string_view str, NamedOutput *result);
+  static bool NameToOutput(beagleg::string_view str, NamedOutput *result);
   static const char *OutputToName(NamedOutput output);
 
   // Return GPIO definition for various types of out/input. Count starts with 1.

--- a/src/hershey.cc
+++ b/src/hershey.cc
@@ -35,7 +35,7 @@ struct HersheyGlyph {
 extern const HersheyGlyph hershey_simplex[];
 }  // namespace
 
-float TextWidth(std::string_view str, float size) {
+float TextWidth(beagleg::string_view str, float size) {
   float longest_line = 0;
   size /= 25.0f;  // The actual coordinates are roughly in the range 0..25
 
@@ -52,7 +52,7 @@ float TextWidth(std::string_view str, float size) {
   return std::max(longest_line, w);
 }
 
-void DrawText(std::string_view str, float tx, float ty, TextAlign align,
+void DrawText(beagleg::string_view str, float tx, float ty, TextAlign align,
               float size,
               const std::function<void(bool do_line, float x, float y)> &draw) {
   float dx = 0;

--- a/src/hershey.h
+++ b/src/hershey.h
@@ -20,12 +20,13 @@
 #define _BEAGLEG_HERSHEY_H_
 
 #include <functional>
-#include <string_view>
+
+#include "common/string-util.h"
 
 // -- Functions to draw ASCII text in the Hershey simplex font.
 
 // Determine the width of the text if drawn with DrawText()
-float TextWidth(std::string_view str, float size);
+float TextWidth(beagleg::string_view str, float size);
 
 enum class TextAlign { kLeft, kCenter, kRight };
 
@@ -35,7 +36,7 @@ enum class TextAlign { kLeft, kCenter, kRight };
 //   "x", "y"   - the position to moveto/lineto
 // The function makes it independent of any output device and easy to
 // adapt in any environment.
-void DrawText(std::string_view str, float tx, float ty, TextAlign align,
+void DrawText(beagleg::string_view str, float tx, float ty, TextAlign align,
               float size,
               const std::function<void(bool do_line, float x, float y)>& draw);
 

--- a/src/machine-control-config_test.cc
+++ b/src/machine-control-config_test.cc
@@ -19,8 +19,6 @@
 
 #include <gtest/gtest.h>
 
-#include <iostream>
-
 #include "config-parser.h"
 #include "gcode-machine-control.h"  // contains struct MachineControlConfig
 #include "gcode-parser/gcode-parser.h"

--- a/src/machine-control.cc
+++ b/src/machine-control.cc
@@ -116,8 +116,8 @@ static int fyi_option_gone(const char *prog) {
 }
 
 // Call with <uid>:<gid> string.
-static bool drop_privileges(std::string_view privs) {
-  std::vector<std::string_view> pair = SplitString(privs, ":");
+static bool drop_privileges(beagleg::string_view privs) {
+  std::vector<beagleg::string_view> pair = SplitString(privs, ":");
   if (pair.empty() || pair.size() > 2) {
     Log_error("Drop privileges: Require colon separated <uid>[:<gid>]");
     return false;

--- a/src/spindle-control.cc
+++ b/src/spindle-control.cc
@@ -60,7 +60,7 @@ static void sleep_ms(int ms) {
   struct timespec req;
   struct timespec rem;
   req.tv_sec = ms / 1000;
-  req.tv_nsec = (ms % 1000L) * 1000'000L;
+  req.tv_nsec = (ms % 1000L) * 1000000L;
   if (nanosleep(&req, &rem) == -1) {
     if (errno == EINTR) {
       Log_error("sleep_ms: nanosleep() was interrupted (%ld.%ld sec remaining)",


### PR DESCRIPTION
Some older devices do not yet have a modern compiler. The default standard is still c++17, but it can be set to c++11 in the toplevel Makefile.