### PR TITLE
nix: build GNU binutils for the PRU (pru-elf) and add it to the shell.

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -49,6 +49,11 @@ the root of the environment.
 nix-shell
 ```
 
+Besides the host build dependencies, the shell provides the GNU PRU
+binutils from `nix/pru-toolchain.nix` -- handy to inspect assembled
+PRU code (`pru-elf-objdump -D -b binary -m pru ...`) and needed to
+package PRU firmware as remoteproc-loadable ELFs.
+
 The shell pulls in the host build deps: gtest, valgrind, clang-tools,
 lcov, ghostscript, graphviz.
 

--- a/nix/pru-toolchain.nix
+++ b/nix/pru-toolchain.nix
@@ -1,0 +1,34 @@
+# GNU PRU binutils (--target=pru-elf), used to package the remoteproc
+# firmware ELF. Built from the upstream release because nixpkgs'
+# lib.systems.parse does not know "pru" as a CPU family, which rules
+# out the usual pkgsCross path. Debian ships the same tools as
+# binutils-pru.
+{ stdenv, fetchurl, texinfo, bison }:
+{
+  binutils-pru = stdenv.mkDerivation rec {
+    pname = "binutils-pru";
+    version = "2.43";
+
+    src = fetchurl {
+      url = "mirror://gnu/binutils/binutils-${version}.tar.xz";
+      sha256 = "0rck6wqdc95ink0abkhlkvcj5wragx4kk77wsp8h33xc8gs0cdmm";
+    };
+
+    nativeBuildInputs = [ texinfo bison ];
+
+    configureFlags = [
+      "--target=pru-elf"
+      # Release tarballs trip new warnings on newer host compilers;
+      # don't let -Werror break the build.
+      "--disable-werror"
+      # No gettext message translations: drops that dependency,
+      # English-only diagnostics are fine for a build tool.
+      "--disable-nls"
+      # Don't record timestamps/uid in ar archives, so outputs are
+      # bit-reproducible as nix expects.
+      "--enable-deterministic-archives"
+    ];
+
+    enableParallelBuilding = true;
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -12,6 +12,7 @@ let
     };
     patches = [];
   });
+  pru = pkgs.callPackage ./nix/pru-toolchain.nix {};
 in
 pkgs.mkShell {
   buildInputs = with pkgs;
@@ -26,6 +27,7 @@ pkgs.mkShell {
       ghostscript
       llvmPackages_19.clang-tools
       graphviz
+      pru.binutils-pru
     ];
   shellHook =
   ''


### PR DESCRIPTION
nixpkgs has no pkgsCross.pru (its platform parser does not know the CPU family), so build it from the upstream release. Debian ships the same tools as binutils-pru.